### PR TITLE
Fix __init__.py file in ligotools package

### DIFF
--- a/ligotools/__init__.py
+++ b/ligotools/__init__.py
@@ -1,0 +1,4 @@
+"""
+ligotools package: contains utilities for reading LIGO data.
+"""
+__all__ = ["readligo"]


### PR DESCRIPTION
Added a short docstring to __init__.py to properly initialize the ligotools package.